### PR TITLE
Add quantity API

### DIFF
--- a/quantity_api.py
+++ b/quantity_api.py
@@ -21,20 +21,6 @@ q1 = u.Quantity(11.412, unit=u.meter)
 q2 = u.Quantity(21.52, "cm")
 q3 = u.Quantity(11.412) # raises an exception because no unit specified
 
-# A Quantity object may also have an uncertainty associated with them, but this will be 
-#   implemented at a later date, probably in a subclass of Quantity. The usage might look
-#   something like this:
-q1 = u.Quantity(14.6, u.meter, uncertainty=some_probability_distribution)
-q2 = u.Quantity(14.6, u.meter, uncertainty=(0.1, 0.2))
-q1 = u.Quantity(11.41, u.meter, uncertainty=0.01) 
-q2 = u.Quantity(14.6, u.meter, uncertainty=0.2)
-
-# We will also support a number of astropy Uncertainty classes, but the names have not been
-#   decided upon. That will look like:
-q1 = u.Quantity(14.6, u.meter, uncertainty=StandardDeviationUncertainty(0.5))
-q2 = u.Quantity(14.6, u.meter, uncertainty=VarianceUncertainty(0.25))
-# etc.
-
 # ----------
 # Operations
 # ----------
@@ -59,14 +45,6 @@ q2 = u.Quantity(15.37, u.second)
 q1 / q2 # valid, returns an object in meters per second
 q1 + q2 # raises an exception
 
-# For objects with uncertainties, we can't propagate errors unless the user uses one of the astropy
-#   Uncertainty classes, which know how to do their own error propagation (but are still in development).
-
-# In the future, something like this will work (names may change):
-q1 = u.Quantity(11.41, u.meter, uncertainty=StandardDeviationUncertainty(0.35))
-q2 = u.Quantity(15.37, u.meter, uncertainty=StandardDeviationUncertainty(0.11))
-new_quantity = q1 + q2 # error propagation done for the user
-
 # The Units package will have a native type that represents "no unit." Operations with such dimensionless
 #   objects will look like this (replace unit="" with whatever is decided for Unit package):
 Quantity(15.1234, unit=u.kilogram) * Quantity(0.75, unit="") # should work
@@ -89,6 +67,9 @@ q1 = Quantity(194.118, unit=u.kilometer)
 q1.value # returns 194.118
 q1.to(u.centimeter).value # returns the *value* (just a number, not an object) of this quantity in the specified units
 
+# to find out the unit of a quantity object, use the unit property
+q1.unit
+
 # --------
 # Equality
 # --------
@@ -102,3 +83,31 @@ Quantity(1, units=u.m) == Quantity(1, units=u.s) # raises IncompatibleUnitError(
 # Printing the quantity should display the number and the units when converting to a string
 str(quantity) # returns '11.412 m'
 repr(quantity) # returns '<Quantity Value: 11.412 Units: meter>' or something
+
+# ================================================================================================
+
+# -----------
+# Uncertainty  --  Note: The below is preliminary, and may be implemented on a subclass instead!
+# -----------
+
+# A Quantity object may also have an uncertainty associated with them, but this will be 
+#   implemented at a later date, probably in a subclass of Quantity. The usage might look
+#   something like this:
+q1 = u.Quantity(14.6, u.meter, uncertainty=some_probability_distribution)
+q2 = u.Quantity(14.6, u.meter, uncertainty=(0.1, 0.2))
+q1 = u.Quantity(11.41, u.meter, uncertainty=0.01) 
+q2 = u.Quantity(14.6, u.meter, uncertainty=0.2)
+
+# We will also support a number of astropy Uncertainty classes, but the names have not been
+#   decided upon. That will look like:
+q1 = u.Quantity(14.6, u.meter, uncertainty=StandardDeviationUncertainty(0.5))
+q2 = u.Quantity(14.6, u.meter, uncertainty=VarianceUncertainty(0.25))
+# etc.
+
+# For objects with uncertainties, we can't propagate errors unless the user uses one of the astropy
+#   Uncertainty classes, which know how to do their own error propagation (but are still in development).
+
+# In the future, something like this will work (names may change):
+q1 = u.Quantity(11.41, u.meter, uncertainty=StandardDeviationUncertainty(0.35))
+q2 = u.Quantity(15.37, u.meter, uncertainty=StandardDeviationUncertainty(0.11))
+new_quantity = q1 + q2 # error propagation done for the user


### PR DESCRIPTION
In this pull request is a rough sketch of what we want the Quantity class to be able to do. It may not be complete, and there are a few thing we need to discuss:
1. How do we decide which units to return when performing operations between quantities? 
2. Since 'in' is a reserved word in Python, and 'as' is as well (arg), we could do something like 'in_'? Does this seem awkward? Is there a better solution?
