### PR TITLE
Conversion from celestial to altaz coordinates

### DIFF
--- a/coordinates_example.py
+++ b/coordinates_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+﻿#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
@@ -267,6 +267,11 @@ c.l
 c = HorizontalCoordinates(alt, az, epoch=timeobj)
 
 
+# Coordinates located on the Earth (for instance, the location of an observatory)
+# can also be represented.
+c = LatitudeLongitude(lat, lon)
+
+
 # Coordinate Factory
 # ------------------
 '''
@@ -333,6 +338,21 @@ class CustomCoordinate(BaseCoordinate):
 # allows both ways of converting
 mycoord1 = c.my_coord
 mycoord2 = c.convert_to(CustomCoordinate)
+
+
+# Conversions from celestial to horizontal
+# ----------------------------------------
+#
+# It is possible to convert to alt/az if one does specify a location and time.
+
+kpno = LatitudeLongitude(31.9583, -111.5967, unit=(u.degree, u.degree))
+obstime = astropy.time.Time('2014-01-15 01:02:03', scale='utc')
+altaz = c.convert_to(HorizontalCoordinate, location=kpno, time=obstime)
+
+# Because the above conversion is a particularly common one, there is 
+# a more convenient syntax as well:
+
+altaz = c.observe_from(kpno, obstime)
 
 
 # Separations


### PR DESCRIPTION
At the #hackAAS hack day, I started helping @elovegrove to modify her program PYRO (https://github.com/elovegrove/PYRO) to use astropy.coordinates. However I quickly discovered that astropy.coordinates is still missing an interface to convert from celestial coordinates to apparent horizontal coordinates at some observatory. So, I started coding. 

The first ingredient is some way to represent an observer's position on the earth. I implemented a LatitudeLongitude coordinates class, following the examples of the other systems. For now there's only one such system and it doesn't have any transformations, and also it ignores the details of the geoid to just treat the Earth as a perfect sphere. (I imagine if eventually more precision is needed, one could use the transformations framework to define conversions between various geoid models… but that's getting ahead of the story). 

Then, the next question is, what should the API be for using LatitudeLongitudes to get a HorizontalCoordinates? I propose something like this: 

```
>>> kpno = coord.LatitudeLongitude(31.9583, -111.5967, unit=(u.degree, u.degree))
>>> star = coord.ICRSCoordinates(ra=10.68458, dec=41.26917, unit=(u.degree, u.degree))
>>> time = astropy.time.Time('2014-01-15 01:02:03', scale='utc')
>>>
>>> star.observed_from(kpno, time)
<HorizontalCoordinates object>
```

One could conversely imagine making it a function on the observatory location instead:

```
>>> kpno.observe(star, time)
<HorizontalCoordinates object>
```

Either API could work fine. It just seems a bit cleaner to me to have the time and place of the observation treated identically, as part of the function call.  It should still support a syntax using the convert_to function, something like

```
>>> altaz = c.convert_to(HorizontalCoordinate, location=kpno, time=obstime)
```

but I think this is a common enough conversion that it deserves some syntactic sugar. Thoughts? 
